### PR TITLE
Lock down Ruby version for build consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image:
-FROM ruby
+FROM ruby:2.4
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs


### PR DESCRIPTION
Fixed Ruby version to 2.4 to accommodate Nokogiri gem build